### PR TITLE
Fix creation of systemd service

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,11 +4,11 @@ maintainer_email 'ops@dnsimple.com'
 license          'Apache 2.0'
 description      'Installs/Configures exabgp'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.0'
+version          '0.3.0'
 
 supports 'ubuntu', '>= 12.04'
 supports 'centos', '>= 6.0'
 
 depends 'python'
 depends 'runit'
-depends 'systemd'
+depends 'systemd', '~> 3.2.2'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -72,9 +72,11 @@ runit_service 'exabgp' do
 end unless systemd_enabled
 
 systemd_service 'exabgp' do
-  description 'ExaBGP service'
-  after node[:exabgp][:systemd][:after]
-  condition_path_exists '/etc/exabgp/exabgp.conf'
+  unit do
+    description 'ExaBGP service'
+    after node[:exabgp][:systemd][:after]
+    condition_path_exists '/etc/exabgp/exabgp.conf'
+  end
 
   service do
     environment 'exabgp_daemon_daemonize' => 'false'


### PR DESCRIPTION
 - Bump cookbook version to `0.3.0`
 - Lock `systemd` version to `~> 3.2.2`
 - Move `description`, `after` and `condition_path_exists` under `unit` section

This patch fixes the following issue:

```
05:34:25        NoMethodError
05:34:25        -------------
05:34:25        undefined method `description' for Custom resource systemd_service from cookbook systemd
05:34:25        
05:34:25        Relevant File Content:
05:34:25        ----------------------
05:34:25        /tmp/kitchen/cache/cookbooks/exabgp/recipes/default.rb:
05:34:25       
05:34:25         74:  systemd_service 'exabgp' do
05:34:25         75>>   description 'ExaBGP service'
05:34:25         76:    after node[:exabgp][:systemd][:after]
05:34:25         77:    condition_path_exists '/etc/exabgp/exabgp.conf'
05:34:25         78:  
05:34:25         79:    service do
05:34:25         80:      environment 'exabgp_daemon_daemonize' => 'false'
05:34:25         81:      exec_start '/usr/src/exabgp/sbin/exabgp /etc/exabgp/exabgp.conf'
05:34:25         82:      exec_reload '/bin/kill -s USR1 $MAINPID'
05:34:25         83:      user 'nobody'
05:34:25         84:    end
```