### PR TITLE
migrate to poise python and Chef12+ syntax

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,11 +1,13 @@
 ---
 driver_plugin: vagrant
+driver_config:
+    require_chef_omnibus: 12
 
 provisioner:
-  name: chef_solo
+  name: chef_zero
 
 platforms:
-  - name: centos-7.1
+  - name: centos-7.6
 
 suites:
   - name: source

--- a/attributes/exabgp.rb
+++ b/attributes/exabgp.rb
@@ -23,3 +23,7 @@ default[:exabgp][:hubot][:secret] = 'secret'
 default[:exabgp][:hubot][:event] = 'sre'
 
 default[:exabgp][:systemd][:after] = %w(network.target)
+
+# lock pip version, poise-python is broken with later
+# https://github.com/vinted/chef/blob/c5af12a421fefbc55e60240329e014f1d7f4a690/cookbooks/vinted-python/attributes/default.rb#L3
+default['poise-python']['options']['pip_version'] = '9.0.3'

--- a/attributes/exabgp.rb
+++ b/attributes/exabgp.rb
@@ -1,28 +1,28 @@
-default[:exabgp][:local_as] = 12345
-default[:exabgp][:peer_as] = 12345
-default[:exabgp][:community] = [0]
+default['exabgp']['local_as'] = 12345
+default['exabgp']['peer_as'] = 12345
+default['exabgp']['community'] = [0]
 
-default[:exabgp][:hold_time] = 20
-default[:exabgp][:local_preference] = nil
+default['exabgp']['hold_time'] = 20
+default['exabgp']['local_preference'] = nil
 
-default[:exabgp][:ipv4][:neighbor] = '127.0.0.1'
-default[:exabgp][:ipv4][:anycast] = ['127.0.0.1/32', '127.0.0.2/32']
-default[:exabgp][:ipv4][:enable_static_route] = true
+default['exabgp']['ipv4']['neighbor'] = '127.0.0.1'
+default['exabgp']['ipv4']['anycast'] = ['127.0.0.1/32', '127.0.0.2/32']
+default['exabgp']['ipv4']['enable_static_route'] = true
 
-default[:exabgp][:ipv6][:neighbor] = nil
-default[:exabgp][:ipv6][:anycast] = ['::1/128']
+default['exabgp']['ipv6']['neighbor'] = nil
+default['exabgp']['ipv6']['anycast'] = ['::1/128']
 
-default[:exabgp][:source_version] = 'master'
-default[:exabgp][:bin_path] = '/usr/local/bin/exabgp'
+default['exabgp']['source_version'] = 'master'
+default['exabgp']['bin_path'] = '/usr/local/bin/exabgp'
 
-default[:exabgp][:watchdog_flag_file] = '/tmp/exabgp-announce'
+default['exabgp']['watchdog_flag_file'] = '/tmp/exabgp-announce'
 
-default[:exabgp][:hubot][:enable] = false
-default[:exabgp][:hubot][:url] = 'http://localhost:9998'
-default[:exabgp][:hubot][:secret] = 'secret'
-default[:exabgp][:hubot][:event] = 'sre'
+default['exabgp']['hubot'][:enable] = false
+default['exabgp']['hubot'][:url] = 'http://localhost:9998'
+default['exabgp']['hubot'][:secret] = 'secret'
+default['exabgp']['hubot'][:event] = 'sre'
 
-default[:exabgp][:systemd][:after] = %w(network.target)
+default['exabgp']['systemd']['after'] = %w(network.target)
 
 # lock pip version, poise-python is broken with later
 # https://github.com/vinted/chef/blob/c5af12a421fefbc55e60240329e014f1d7f4a690/cookbooks/vinted-python/attributes/default.rb#L3

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@dnsimple.com'
 license          'Apache 2.0'
 description      'Installs/Configures exabgp'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.3.0'
+version          '0.4.0'
 
 supports 'ubuntu', '>= 12.04'
 supports 'centos', '>= 6.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,6 +9,6 @@ version          '0.3.0'
 supports 'ubuntu', '>= 12.04'
 supports 'centos', '>= 6.0'
 
-depends 'python'
+depends 'poise-python'
 depends 'runit'
 depends 'systemd', '~> 3.2.2'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,27 +28,27 @@ include_recipe 'runit' unless systemd_enabled
 
 python_package 'exabgp' do
   action :install
-end unless node[:recipes].include? 'exabgp::source'
+end unless node['recipes'].include? 'exabgp::source'
 
 directory '/etc/exabgp'
 
 template 'exabgp: config' do
   path '/etc/exabgp/exabgp.conf'
   source 'exabgp.conf.erb'
-  variables( router_id: node.ipaddress,
-             hold_time: node[:exabgp][:hold_time],
-             neighbor_ipv4: node[:exabgp][:ipv4][:neighbor],
-             local_address_ipv4: node.ipaddress,
-             local_preference: node[:exabgp][:local_preference],
+  variables( router_id: node['ipaddress'],
+             hold_time: node['exabgp']['hold_time'],
+             neighbor_ipv4: node['exabgp']['ipv4']['neighbor'],
+             local_address_ipv4: node['ipaddress'],
+             local_preference: node['exabgp']['local_preference'],
              route_ipv4: route('ipv4'),
-             enable_ipv4_static_route: node[:exabgp][:ipv4][:enable_static_route],
-             enable_hubot: node[:exabgp][:hubot][:enable],
-             neighbor_ipv6: node[:exabgp][:ipv6][:neighbor],
-             local_address_ipv6: node[:ip6address],
+             enable_ipv4_static_route: node['exabgp']['ipv4']['enable_static_route'],
+             enable_hubot: node['exabgp']['hubot']['enable'],
+             neighbor_ipv6: node['exabgp']['ipv6']['neighbor'],
+             local_address_ipv6: node['ip6address'],
              route_ipv6: route('ipv6'),
-             local_as: node[:exabgp][:local_as],
-             peer_as: node[:exabgp][:peer_as],
-             community: node[:exabgp][:community].join(' '))
+             local_as: node['exabgp']['local_as'],
+             peer_as: node['exabgp']['peer_as'],
+             community: node['exabgp']['community'].join(' '))
   mode '644'
   notifies :run, 'execute[reload-exabgp-config]' unless systemd_enabled
   notifies :reload, 'service[exabgp]' if systemd_enabled
@@ -57,9 +57,9 @@ end
 template '/etc/exabgp/neighbor-changes.rb' do
   source 'neighbor-changes.rb.erb'
   variables hubot_publish: {
-              url: node[:exabgp][:hubot][:url],
-              secret: node[:exabgp][:hubot][:secret],
-              event: node[:exabgp][:hubot][:event]
+              url: node['exabgp']['hubot']['url'],
+              secret: node['exabgp']['hubot']['secret'],
+              event: node['exabgp']['hubot']['event']
             }
   mode 0755
   notifies :run, 'execute[reload-exabgp-config]' unless systemd_enabled
@@ -78,7 +78,7 @@ end unless systemd_enabled
 systemd_service 'exabgp' do
   unit do
     description 'ExaBGP service'
-    after node[:exabgp][:systemd][:after]
+    after node['exabgp']['systemd']['after']
     condition_path_exists '/etc/exabgp/exabgp.conf'
   end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,10 +19,14 @@
 
 systemd_enabled = ::File.open('/proc/1/comm').gets.chomp == 'systemd'
 
-include_recipe 'python'
+python_runtime 'system' do
+  version '2'
+  provider :system
+end
+
 include_recipe 'runit' unless systemd_enabled
 
-python_pip 'exabgp' do
+python_package 'exabgp' do
   action :install
 end unless node[:recipes].include? 'exabgp::source'
 

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -2,10 +2,10 @@ package 'git-core'
 
 git '/usr/src/exabgp' do
   repository 'https://github.com/Exa-Networks/exabgp.git'
-  reference node[:exabgp][:source_version]
+  reference node['exabgp']['source_version']
   action :sync
 end
 
-node.override[:exabgp][:bin_path] = '/usr/src/exabgp/sbin/exabgp'
+node.override['exabgp']['bin_path'] = '/usr/src/exabgp/sbin/exabgp'
 
 include_recipe 'exabgp::default'

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -6,6 +6,6 @@ git '/usr/src/exabgp' do
   action :sync
 end
 
-node.set[:exabgp][:bin_path] = '/usr/src/exabgp/sbin/exabgp'
+node.override[:exabgp][:bin_path] = '/usr/src/exabgp/sbin/exabgp'
 
 include_recipe 'exabgp::default'

--- a/templates/default/sv-exabgp-run.erb
+++ b/templates/default/sv-exabgp-run.erb
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec chpst -u nobody <%= node[:exabgp][:bin_path] %> /etc/exabgp/exabgp.conf
+exec chpst -u nobody <%= node['exabgp']['bin_path'] %> /etc/exabgp/exabgp.conf


### PR DESCRIPTION
- Migrate `python` depends to `poise-python`
- Chnage node attribute access syntax to preferred in Chef12+
- Bump cookbook version to `0.4.0`

Tested with `vinted-exabgp 0.4.2`:
* converge with Berksfile `cookbook 'exabgp', git: 'git://github.com/vinted/exabgp-cookbook.git', tag: 'v0.3.0-vinted'`
* second converge with `cookbook 'exabgp', git: 'git://github.com/vinted/exabgp-cookbook.git', ref: '0ae588695ef8b6d18181a6f12d5058d7822bdc93'`
